### PR TITLE
Fixed, Add Item button on the create invoice page.

### DIFF
--- a/application/modules/users/views/invoices/newinvoice.php
+++ b/application/modules/users/views/invoices/newinvoice.php
@@ -241,7 +241,7 @@
                             </thead>
                             <tbody class="body-items">
                                 <?php
-                                $thisDir = ltrim(str_replace(getcwd(), '', dirname(__FILE__)), '/');
+                                $thisDir = ltrim(str_replace(getcwd(), '', dirname(__FILE__)), '\\');
                                 if (isset($_POST['items'])) {
                                     foreach ($_POST['items'] as $itemPost) {
                                         include $thisDir . '/itemTableTr.php';


### PR DESCRIPTION
The button previously would not respond because it had the wrong path to the Items table.